### PR TITLE
UTXO re-alignment

### DIFF
--- a/src/active_raft.rs
+++ b/src/active_raft.rs
@@ -193,6 +193,11 @@ impl ActiveRaft {
     }
 
     /// Create a snapshot at the given idx with the given data.
+    ///
+    /// ## Arguments
+    /// * `idx` - The index of the snapshot
+    /// * `data` - The data to snapshot
+    /// * `backup` - Whether or not to backup the DB
     pub fn create_snapshot(&mut self, idx: u64, data: RaftData, backup: bool) {
         if self.use_raft {
             self.cmd_tx

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -26,12 +26,12 @@ use bincode::{deserialize, serialize};
 use bytes::Bytes;
 use naom::primitives::asset::TokenAmount;
 use naom::primitives::block::Block;
-use naom::primitives::transaction::{DrsTxHashSpec, Transaction};
+use naom::primitives::transaction::{DrsTxHashSpec, OutPoint, Transaction};
 use naom::utils::druid_utils::druid_expectations_are_met;
 use naom::utils::script_utils::{tx_has_valid_create_script, tx_is_valid};
 use naom::utils::transaction_utils::construct_tx_hash;
 use serde::Serialize;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 use std::{
     error::Error,
@@ -353,13 +353,36 @@ impl ComputeNode {
         self.node_raft.get_local_tx_druid_pool()
     }
 
-    // The current druid pool of pending DDE transactions
+    /// The current druid pool of pending DDE transactions
     pub fn get_pending_druid_pool(&self) -> &DruidPool {
         &self.druid_pool
     }
 
+    /// Get request list
     pub fn get_request_list(&self) -> &BTreeSet<SocketAddr> {
         &self.request_list
+    }
+
+    /// Get a clone of `pk_cache` element of `TrackedUtxoSet`
+    ///
+    /// ## NOTE
+    ///
+    /// Only used during tests
+    pub fn get_pk_cache(&self) -> HashMap<String, Vec<OutPoint>> {
+        self.node_raft.get_committed_utxo_tracked_pk_cache()
+    }
+
+    /// Remove a `pk_cache` entry from `TrackedUtxoSet`
+    ///
+    /// ## Arguments
+    ///
+    /// * `entry` - The entry to remove
+    ///
+    /// ## NOTE
+    ///
+    /// Only used during tests
+    pub fn remove_pk_cache_entry(&mut self, entry: &str) {
+        self.node_raft.committed_utxo_remove_pk_cache(entry);
     }
 
     /// Return the raft loop to spawn in it own task.

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -26,12 +26,12 @@ use bincode::{deserialize, serialize};
 use bytes::Bytes;
 use naom::primitives::asset::TokenAmount;
 use naom::primitives::block::Block;
-use naom::primitives::transaction::{DrsTxHashSpec, OutPoint, Transaction};
+use naom::primitives::transaction::{DrsTxHashSpec, Transaction};
 use naom::utils::druid_utils::druid_expectations_are_met;
 use naom::utils::script_utils::{tx_has_valid_create_script, tx_is_valid};
 use naom::utils::transaction_utils::construct_tx_hash;
 use serde::Serialize;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::{
     error::Error,
@@ -368,7 +368,10 @@ impl ComputeNode {
     /// ## NOTE
     ///
     /// Only used during tests
-    pub fn get_pk_cache(&self) -> HashMap<String, BTreeSet<OutPoint>> {
+    #[cfg(test)]
+    pub fn get_pk_cache(
+        &self,
+    ) -> std::collections::HashMap<String, BTreeSet<naom::primitives::transaction::OutPoint>> {
         self.node_raft.get_committed_utxo_tracked_pk_cache()
     }
 
@@ -381,6 +384,7 @@ impl ComputeNode {
     /// ## NOTE
     ///
     /// Only used during tests
+    #[cfg(test)]
     pub fn remove_pk_cache_entry(&mut self, entry: &str) {
         self.node_raft.committed_utxo_remove_pk_cache(entry);
     }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -368,7 +368,7 @@ impl ComputeNode {
     /// ## NOTE
     ///
     /// Only used during tests
-    pub fn get_pk_cache(&self) -> HashMap<String, Vec<OutPoint>> {
+    pub fn get_pk_cache(&self) -> HashMap<String, BTreeSet<OutPoint>> {
         self.node_raft.get_committed_utxo_tracked_pk_cache()
     }
 

--- a/src/compute_raft.rs
+++ b/src/compute_raft.rs
@@ -19,10 +19,10 @@ use bincode::{deserialize, serialize};
 use naom::crypto::sha3_256;
 use naom::primitives::asset::TokenAmount;
 use naom::primitives::block::Block;
-use naom::primitives::transaction::{OutPoint, Transaction};
+use naom::primitives::transaction::Transaction;
 use naom::utils::transaction_utils::get_inputs_previous_out_point;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -870,7 +870,10 @@ impl ComputeRaft {
     /// ## NOTE
     ///
     /// Only used during tests
-    pub fn get_committed_utxo_tracked_pk_cache(&self) -> HashMap<String, BTreeSet<OutPoint>> {
+    #[cfg(test)]
+    pub fn get_committed_utxo_tracked_pk_cache(
+        &self,
+    ) -> std::collections::HashMap<String, BTreeSet<naom::primitives::transaction::OutPoint>> {
         self.consensused.utxo_set.get_pk_cache()
     }
 
@@ -883,6 +886,7 @@ impl ComputeRaft {
     /// ## NOTE
     ///
     /// Only used during tests
+    #[cfg(test)]
     pub fn committed_utxo_remove_pk_cache(&mut self, entry: &str) {
         self.consensused.utxo_set.remove_pk_cache_entry(entry)
     }

--- a/src/compute_raft.rs
+++ b/src/compute_raft.rs
@@ -870,7 +870,7 @@ impl ComputeRaft {
     /// ## NOTE
     ///
     /// Only used during tests
-    pub fn get_committed_utxo_tracked_pk_cache(&self) -> HashMap<String, Vec<OutPoint>> {
+    pub fn get_committed_utxo_tracked_pk_cache(&self) -> HashMap<String, BTreeSet<OutPoint>> {
         self.consensused.utxo_set.get_pk_cache()
     }
 

--- a/src/configurations.rs
+++ b/src/configurations.rs
@@ -141,6 +141,8 @@ pub struct ComputeNodeConfig {
     pub routes_pow: BTreeMap<String, usize>,
     /// Backup block that given modulo result in 0
     pub backup_block_modulo: Option<u64>,
+    /// Check UTXO set block modulo
+    pub utxo_re_align_block_modulo: Option<u64>,
     /// Restore backup if true
     pub backup_restore: Option<bool>,
     /// Enable trigger messages to reset the pipeline when it gets stuck

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -91,6 +91,7 @@ pub struct NetworkConfig {
     pub tls_config: TestTlsSpec,
     pub routes_pow: BTreeMap<String, usize>,
     pub backup_block_modulo: Option<u64>,
+    pub utxo_re_align_block_modulo: Option<u64>,
     pub backup_restore: Option<bool>,
     pub enable_pipeline_reset: Option<bool>,
 }
@@ -1130,6 +1131,7 @@ async fn init_compute(
         compute_api_use_tls: true,
         routes_pow: Default::default(),
         backup_block_modulo: config.backup_block_modulo,
+        utxo_re_align_block_modulo: config.utxo_re_align_block_modulo,
         backup_restore: config.backup_restore,
         enable_trigger_messages_pipeline_reset: config.enable_pipeline_reset,
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3427,7 +3427,7 @@ async fn compute_remove_entry_from_pk_cache<'a>(network: &mut Network, compute: 
 async fn compute_get_pk_cache(
     network: &mut Network,
     compute: &str,
-) -> HashMap<String, Vec<OutPoint>> {
+) -> HashMap<String, BTreeSet<OutPoint>> {
     let c = network.compute(compute).unwrap().lock().await;
     c.get_pk_cache()
 }

--- a/src/tracked_utxo.rs
+++ b/src/tracked_utxo.rs
@@ -33,6 +33,7 @@ impl TrackedUtxoSet {
     /// ## NOTE
     ///
     /// Only used during testing
+    #[cfg(test)]
     pub fn get_pk_cache(&self) -> HashMap<String, BTreeSet<OutPoint>> {
         self.pk_cache.clone()
     }
@@ -46,6 +47,7 @@ impl TrackedUtxoSet {
     /// ## NOTE
     ///
     /// Only used during testing
+    #[cfg(test)]
     pub fn remove_pk_cache_entry(&mut self, entry: &str) {
         self.pk_cache.remove(entry);
     }

--- a/src/tracked_utxo.rs
+++ b/src/tracked_utxo.rs
@@ -28,6 +28,43 @@ pub struct TrackedUtxoSet {
 }
 
 impl TrackedUtxoSet {
+    /// Get a clone of `pk_cache`
+    ///
+    /// ## NOTE
+    ///
+    /// Only used during testing
+    pub fn get_pk_cache(&self) -> HashMap<String, Vec<OutPoint>> {
+        self.pk_cache.clone()
+    }
+
+    /// Remove a `pk_cache` entry
+    ///
+    /// # Arguments
+    ///
+    /// * `entry` - `script_public_key` to remove
+    ///
+    /// ## NOTE
+    ///
+    /// Only used during testing
+    pub fn remove_pk_cache_entry(&mut self, entry: &str) {
+        self.pk_cache.remove(entry);
+    }
+
+    /// Re-align `pk_cache` to `base`
+    pub fn re_align(&mut self) {
+        self.pk_cache = create_pk_cache_from_base(&self.base);
+    }
+
+    /// Get base `UtxoSet` length
+    pub fn get_base_outpoint_count(&self) -> u64 {
+        self.base.len() as u64
+    }
+
+    /// Get tracked `UtxoSet` set length
+    pub fn get_tracked_outpoint_count(&self) -> u64 {
+        self.pk_cache.values().map(|v| v.len() as u64).sum()
+    }
+
     /// Create a new TrackedUtxoSet from `UtxoSet` base
     pub fn new(base: UtxoSet) -> Self {
         let pk_cache = create_pk_cache_from_base(&base);

--- a/src/upgrade/tests.rs
+++ b/src/upgrade/tests.rs
@@ -698,6 +698,7 @@ fn complete_network_config(initial_port: u16) -> NetworkConfig {
         tls_config: get_test_tls_spec(),
         routes_pow: Default::default(),
         backup_block_modulo: Default::default(),
+        utxo_re_align_block_modulo: Default::default(),
         backup_restore: Default::default(),
         enable_pipeline_reset: Default::default(),
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,6 +242,25 @@ impl BackupCheck {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct UtxoReAlignCheck {
+    modulo_block_num: Option<u64>,
+}
+
+impl UtxoReAlignCheck {
+    pub fn new(modulo_block_num: Option<u64>) -> Self {
+        Self { modulo_block_num }
+    }
+
+    pub fn need_check(&self, current_block: u64) -> bool {
+        if let Some(modulo) = self.modulo_block_num {
+            current_block != 0 && current_block % modulo == 0
+        } else {
+            false
+        }
+    }
+}
+
 /// Install a global tracing subscriber that listens for events and
 /// filters based on the value of the [`RUST_LOG` environment variable],
 /// if one is not already set.


### PR DESCRIPTION
Allow the `pk_cache` element of `TrackedUtxoSet` to re-align with the `base` `UtxoSet` if misalignment takes place.

This is something that is can be toggled and controlled through the `utxo_re_align_block_modulo` configuration entry for compute nodes.