### PR TITLE
feat(miner): enable taking miner wallet backups

### DIFF
--- a/src/configurations.rs
+++ b/src/configurations.rs
@@ -216,6 +216,8 @@ pub struct MinerNodeConfig {
     pub routes_pow: BTreeMap<String, usize>,
     /// Backup block that given modulo result in 0
     pub backup_block_modulo: Option<u64>,
+    /// Restore backup if true
+    pub backup_restore: Option<bool>,
 }
 
 /// Configuration option for a user node

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1043,6 +1043,7 @@ async fn init_miner(
         miner_api_use_tls: true,
         routes_pow: config.routes_pow.clone(),
         backup_block_modulo: Default::default(),
+        backup_restore: config.backup_restore,
     };
     let info_str = format!("{} -> {}", name, node_info.node_spec.address);
     info!("New Miner {}", info_str);


### PR DESCRIPTION
- Miners will take a backup of their wallets after committing a coinbase transaction
- Miner wallet backups will follow the same procedure as Compute's and Storage's backups