### PR TITLE
Add ability to specify static miner address for new coinbase tx

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,6 +20,10 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Clippy check
+        timeout-minutes: 30
+        run: cargo clippy --all-targets --all-features -- -Dwarnings
+
       - name: Run integration tests
         timeout-minutes: 30
-        run: cargo test --release -- --test-threads=2
+        run: cargo test --release -- --test-threads=1

--- a/src/configurations.rs
+++ b/src/configurations.rs
@@ -218,6 +218,8 @@ pub struct MinerNodeConfig {
     pub backup_block_modulo: Option<u64>,
     /// Restore backup if true
     pub backup_restore: Option<bool>,
+    /// When provided, all new coinbase transactions will be assigned to this address
+    pub static_miner_address: Option<String>,
 }
 
 /// Configuration option for a user node

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -157,6 +157,7 @@ pub struct MinerNode {
     last_pow: Option<ProofOfWork>,
     current_coinbase: Option<(String, Transaction)>,
     current_payment_address: Option<String>,
+    static_miner_address: Option<String>,
     aggregation_status: AggregationStatus,
     wait_partition_task: bool,
     received_utxo_set: Option<UtxoSet>,
@@ -207,6 +208,7 @@ impl MinerNode {
         )
         .await?;
         let api_pow_info = to_route_pow_infos(config.routes_pow.clone());
+        let static_miner_address = config.static_miner_address.clone();
 
         MinerNode {
             node,
@@ -221,6 +223,7 @@ impl MinerNode {
             last_pow: None,
             current_coinbase: None,
             current_payment_address: None,
+            static_miner_address,
             aggregation_status: Default::default(),
             received_utxo_set: None,
             wait_partition_task: Default::default(),
@@ -1274,7 +1277,11 @@ impl MinerNode {
     /// Commit our winning mining tx to wallet
     async fn commit_found_coinbase(&mut self) {
         trace!("Committing our latest winning");
-        self.current_payment_address = Some(generate_mining_address(&mut self.wallet_db).await);
+        self.current_payment_address = Some(
+            self.static_miner_address
+                .clone()
+                .unwrap_or(generate_mining_address(&mut self.wallet_db).await),
+        );
         let (hash, transaction) = std::mem::replace(
             &mut self.current_coinbase,
             store_last_coinbase(&self.wallet_db, None).await,
@@ -1534,13 +1541,20 @@ impl MinerNode {
             None
         };
 
-        self.current_payment_address =
-            if let Some(addr) = load_mining_address(&self.wallet_db).await? {
-                debug!("load_local_db: current_payment_address {:?}", addr);
-                Some(addr)
-            } else {
-                Some(generate_mining_address(&mut self.wallet_db).await)
-            };
+        self.current_payment_address = match self.static_miner_address.clone() {
+            Some(static_address) => {
+                warn!("using static miner address: {:?}", static_address);
+                Some(static_address)
+            }
+            None => {
+                if let Some(addr) = load_mining_address(&self.wallet_db).await? {
+                    debug!("load_local_db: current_payment_address {:?}", addr);
+                    Some(addr)
+                } else {
+                    Some(generate_mining_address(&mut self.wallet_db).await)
+                }
+            }
+        };
 
         Ok(self)
     }

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -348,6 +348,11 @@ impl MinerNode {
         self.wallet_db.set_ui_feedback_tx(tx);
     }
 
+    /// Set static miner address.
+    pub fn set_static_miner_address(&mut self, addr: String) {
+        self.static_miner_address = Some(addr);
+    }
+
     /// Extract persistent dbs
     pub async fn take_closed_extra_params(&mut self) -> ExtraNodeParams {
         let wallet_db = self.wallet_db.take_closed_persistent_store().await;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -94,6 +94,7 @@ pub struct NetworkConfig {
     pub utxo_re_align_block_modulo: Option<u64>,
     pub backup_restore: Option<bool>,
     pub enable_pipeline_reset: Option<bool>,
+    pub static_miner_address: Option<String>,
 }
 
 /// Node info to create node
@@ -1044,6 +1045,7 @@ async fn init_miner(
         routes_pow: config.routes_pow.clone(),
         backup_block_modulo: Default::default(),
         backup_restore: config.backup_restore,
+        static_miner_address: config.static_miner_address.clone(),
     };
     let info_str = format!("{} -> {}", name, node_info.node_spec.address);
     info!("New Miner {}", info_str);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -294,7 +294,7 @@ async fn full_flow_single_miner_single_raft_with_static_miner_address_check() {
     //
     // Arrange
     //
-    let network_config = complete_network_config_with_n_compute_miner(11030, true, 1, 1);
+    let network_config = complete_network_config_with_n_compute_miner(11031, true, 1, 1);
     let mut network = Network::create_from_config(&network_config).await;
     let active_nodes = network.all_active_nodes().clone();
     let miner = &active_nodes[&NodeType::Miner][0];
@@ -317,7 +317,7 @@ async fn full_flow_single_miner_single_raft_with_static_miner_address_check() {
     proof_of_work_act(&mut network, CfgPow::First, CfgNum::All, false, None).await;
     send_block_to_storage_act(&mut network, CfgNum::All).await;
 
-    // Create a three blocks
+    // Run the network to mine 2 blocks
     for _ in 0..2 {
         create_block_act(&mut network, Cfg::All, CfgNum::All).await;
         proof_of_work_act(&mut network, CfgPow::Parallel, CfgNum::All, false, None).await;
@@ -340,7 +340,7 @@ async fn full_flow_single_miner_single_raft_with_static_miner_address_check() {
     let tokens_after_mining = user_get_tokens_held(&mut network, user).await;
 
     assert_eq!(initial_tokens, TokenAmount(0));
-    assert_eq!(tokens_after_mining, TokenAmount(7510185)); // 7510185 is the amount of tokens won after mining 2 rounds
+    assert_eq!(tokens_after_mining, TokenAmount(7510185)); // 7510185 is the amount of tokens won after mining 2 blocks
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5012,6 +5012,7 @@ fn basic_network_config(initial_port: u16) -> NetworkConfig {
         utxo_re_align_block_modulo: Default::default(),
         backup_restore: Default::default(),
         enable_pipeline_reset: Default::default(),
+        static_miner_address: Default::default(),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -288,6 +288,62 @@ async fn full_flow_single_miner_single_raft_with_aggregation_tx_check() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn full_flow_single_miner_single_raft_with_static_miner_address_check() {
+    test_step_start();
+
+    //
+    // Arrange
+    //
+    let network_config = complete_network_config_with_n_compute_miner(11030, true, 1, 1);
+    let mut network = Network::create_from_config(&network_config).await;
+    let active_nodes = network.all_active_nodes().clone();
+    let miner = &active_nodes[&NodeType::Miner][0];
+    let compute = &active_nodes[&NodeType::Compute][0];
+    let user = &active_nodes[&NodeType::User][0];
+    let static_addr = user_generate_static_address_for_miner(&mut network, user).await;
+
+    // Update miner's static winning address
+    miner_set_static_miner_address(&mut network, miner, static_addr.clone()).await;
+
+    user_update_running_total(&mut network, user).await;
+    let initial_tokens = user_get_tokens_held(&mut network, user).await;
+
+    //
+    // Act
+    //
+
+    // Genesis block
+    create_first_block_act(&mut network).await;
+    proof_of_work_act(&mut network, CfgPow::First, CfgNum::All, false, None).await;
+    send_block_to_storage_act(&mut network, CfgNum::All).await;
+
+    // Create a three blocks
+    for _ in 0..2 {
+        create_block_act(&mut network, Cfg::All, CfgNum::All).await;
+        proof_of_work_act(&mut network, CfgPow::Parallel, CfgNum::All, false, None).await;
+        send_block_to_storage_act(&mut network, CfgNum::All).await;
+    }
+
+    // Refresh the User's wallet
+    request_utxo_set_act(
+        &mut network,
+        user,
+        compute,
+        UtxoFetchType::AnyOf(vec![static_addr.clone()]),
+    )
+    .await;
+
+    //
+    // Assert
+    //
+    user_update_running_total(&mut network, user).await;
+    let tokens_after_mining = user_get_tokens_held(&mut network, user).await;
+
+    assert_eq!(initial_tokens, TokenAmount(0));
+    assert_eq!(tokens_after_mining, TokenAmount(7510185)); // 7510185 is the amount of tokens won after mining 2 rounds
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn full_flow_multi_miners_raft_1_node() {
     full_flow_multi_miners(complete_network_config_with_n_compute_miner(
         11010, true, 1, 3,
@@ -4447,6 +4503,11 @@ async fn user_send_address_request(
         .unwrap();
 }
 
+async fn user_generate_static_address_for_miner(network: &mut Network, user: &str) -> String {
+    let mut u = network.user(user).unwrap().lock().await;
+    u.generate_static_address_for_miner().await
+}
+
 async fn user_send_donation_address_to_peer(network: &mut Network, from_user: &str, to_user: &str) {
     let user_node_addr = network.get_address(to_user).await.unwrap();
     let mut u = network.user(from_user).unwrap().lock().await;
@@ -4480,6 +4541,11 @@ async fn user_get_received_utxo_set_keys(network: &mut Network, user: &str) -> V
 async fn user_update_running_total(network: &mut Network, user: &str) {
     let mut u = network.user(user).unwrap().lock().await;
     u.update_running_total().await;
+}
+
+async fn user_get_tokens_held(network: &mut Network, user: &str) -> TokenAmount {
+    let u = network.user(user).unwrap().lock().await;
+    u.get_wallet_db().get_fund_store().running_total().tokens
 }
 
 async fn user_get_all_known_addresses(network: &mut Network, user: &str) -> Vec<String> {
@@ -4674,6 +4740,11 @@ async fn miner_has_aggregation_tx_active(
 async fn miner_process_found_block_pow(network: &mut Network, from_miner: &str) {
     let mut m = network.miner(from_miner).unwrap().lock().await;
     m.process_found_block_pow().await;
+}
+
+async fn miner_set_static_miner_address(network: &mut Network, miner: &str, static_addr: String) {
+    let mut m = network.miner(miner).unwrap().lock().await;
+    m.set_static_miner_address(static_addr);
 }
 
 //

--- a/src/upgrade/tests.rs
+++ b/src/upgrade/tests.rs
@@ -720,6 +720,7 @@ fn complete_network_config(initial_port: u16) -> NetworkConfig {
         utxo_re_align_block_modulo: Default::default(),
         backup_restore: Default::default(),
         enable_pipeline_reset: Default::default(),
+        static_miner_address: Default::default(),
     }
     .with_groups(1, 1)
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1314,6 +1314,13 @@ impl UserNode {
         }
     }
 
+    #[cfg(test)]
+    /// Generate a new payment address
+    pub async fn generate_static_address_for_miner(&mut self) -> String {
+        let (addr, _) = self.wallet_db.generate_payment_address().await;
+        addr
+    }
+
     /// Receives a request for a new payment address to be produced
     ///
     /// ### Arguments


### PR DESCRIPTION
Added the ability for the miner node to generate winning coinbase transactions for a specified address instead of a newly generated one.