### PR TITLE
Bugfix export keypairs route

### DIFF
--- a/src/compute.rs
+++ b/src/compute.rs
@@ -1393,7 +1393,9 @@ impl ComputeNode {
                 .node_raft
                 .get_compute_miner_whitelist_addresses()
                 .unwrap_or_default()
-                .contains(&miner_address)
+                .iter()
+                // Only check IP address, since we do not know ephemeral port beforehand
+                .any(|addr| addr.ip() == miner_address.ip())
     }
 
     /// Receive a partition request from a miner node

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -295,7 +295,7 @@ async fn full_flow_single_miner_single_raft_with_static_miner_address_check() {
     //
     // Arrange
     //
-    let network_config = complete_network_config_with_n_compute_miner(11031, true, 1, 1);
+    let network_config = complete_network_config_with_n_compute_miner(11040, true, 1, 1);
     let mut network = Network::create_from_config(&network_config).await;
     let active_nodes = network.all_active_nodes().clone();
     let miner = &active_nodes[&NodeType::Miner][0];


### PR DESCRIPTION
The main goal of this bugfix is to export key-pairs in an unencrypted format. This response body can then later be used to import key-pairs again.

The reason for this is encrypted key-pairs require the master key to decrypt. Once you've exported them, and try to import them into a brand-new wallet DB, the master key will be different, resulting in a failure to decrypt.

It is up to whomever is running the node to ensure there is a TLS-layer encryption between the API endpoint and end-user to safely transport the keys.