### PR TITLE
feat(comms): make compute send heartbeat message

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -357,7 +357,7 @@ async fn new_self_node_with_port(node_type: NodeType, port: u16) -> (Node, Socke
     bind_address.set_port(port);
 
     let tcp_tls_config = TcpTlsConfig::new_no_tls(bind_address);
-    let self_node = Node::new(&tcp_tls_config, 20, node_type, false)
+    let self_node = Node::new(&tcp_tls_config, 20, node_type, false, false)
         .await
         .unwrap();
     socket_address.set_port(self_node.local_address().port());

--- a/src/bin/node_settings_local_raft_1_run.sh
+++ b/src/bin/node_settings_local_raft_1_run.sh
@@ -5,7 +5,7 @@ echo "//-----------------------------//"
 echo "Building nodes"
 echo "//-----------------------------//"
 echo " "
-cargo build --bins --release
+#cargo build --bins --release
 if [ "$?" != "0" ]
 then
     exit 1
@@ -35,8 +35,8 @@ then
     USER_LOG=$5
 else
     STORAGE_LOG=debug
-    COMPUTE_LOG=warn
-    MINER_LOG=warn
+    COMPUTE_LOG=debug
+    MINER_LOG=debug
     USER_LOG=debug
 fi
 

--- a/src/comms_handler/node.rs
+++ b/src/comms_handler/node.rs
@@ -297,7 +297,6 @@ impl Node {
 
                 let peers: Vec<SocketAddr> = node
                     .peers
-                    .clone()
                     .read()
                     .await
                     .iter()
@@ -727,6 +726,14 @@ impl Node {
             .write()
             .await
             .retain(|addr, _| !stale_peers.contains(addr))
+    }
+
+    pub fn abort_heartbeat_handle(&mut self) {
+        if let Some(handle) = self.heartbeat_handle.as_mut() {
+            handle.abort()
+        }
+
+        self.heartbeat_handle = None;
     }
 
     /// Prepares and sends a handshake message to a given peer.

--- a/src/comms_handler/node.rs
+++ b/src/comms_handler/node.rs
@@ -98,15 +98,15 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::{fmt, io};
-use tokio::time::{timeout, Duration};
+use tokio::time::{interval, timeout, Duration};
 use tokio::{
-    self,
+    self, spawn,
     sync::{mpsc, oneshot, Mutex, RwLock},
     task::JoinHandle,
 };
 use tokio_stream::{Stream, StreamExt};
 use tokio_util::codec::{length_delimited, FramedRead, FramedWrite, LengthDelimitedCodec};
-use tracing::{error, info, info_span, trace, warn, Span};
+use tracing::{debug, error, info, info_span, trace, warn, Span};
 use tracing_futures::Instrument;
 
 extern crate serde_json;
@@ -118,6 +118,9 @@ const FANOUT: usize = 8;
 
 /// Max. number of gossip message retransmissions.
 const GOSSIP_MAX_TTL: u8 = 4;
+
+/// Generic Heartbeat interval in seconds
+const HEART_BEAT_INTERVAL: u64 = 3; // seconds
 
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5); // 5 seconds is just a wild guess. Tweak if necessary.
 
@@ -160,6 +163,8 @@ pub struct Node {
     seen_gossip_messages: Arc<RwLock<HashSet<Token>>>,
     /// Connect to all unknown contacts in HandshakeResponse
     connect_to_handshake_contacts: bool,
+    /// Threadhandle for an HeartBeat Prober
+    heartbeat_handle: Option<Arc<JoinHandle<()>>>,
 }
 
 pub(crate) struct Peer {
@@ -214,6 +219,7 @@ impl Node {
         peer_limit: usize,
         node_type: NodeType,
         disable_listening: bool,
+        send_heartbeat_messages: bool,
     ) -> Result<Self> {
         Self::new_with_version(
             config,
@@ -221,6 +227,7 @@ impl Node {
             node_type,
             NETWORK_VERSION,
             disable_listening,
+            send_heartbeat_messages,
         )
         .await
     }
@@ -239,6 +246,7 @@ impl Node {
         node_type: NodeType,
         network_version: u32,
         disable_listening: bool,
+        send_heartbeat_messages: bool,
     ) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
 
@@ -263,12 +271,52 @@ impl Node {
             event_rx: Arc::new(Mutex::new(event_rx)),
             seen_gossip_messages: Arc::new(RwLock::new(HashSet::new())),
             connect_to_handshake_contacts: false,
+            heartbeat_handle: None,
         };
 
         if !disable_listening {
             node = node.listen(listener).await?;
         }
+
+        if send_heartbeat_messages {
+            let handle = node.begin_sending_heartbeat_messages().await;
+            node.heartbeat_handle = Some(Arc::new(handle));
+        }
+
         Ok(node)
+    }
+
+    // Periodically sends out an heartbeat message to all connected peers to identify
+    // and disconnect from stale peers.
+    async fn begin_sending_heartbeat_messages(&self) -> JoinHandle<()> {
+        let mut node = self.clone();
+        spawn(async move {
+            let mut interval = interval(Duration::from_secs(HEART_BEAT_INTERVAL));
+            loop {
+                interval.tick().await;
+
+                let peers: Vec<SocketAddr> = node
+                    .peers
+                    .clone()
+                    .read()
+                    .await
+                    .iter()
+                    .map(|(addr, _)| addr)
+                    .cloned()
+                    .collect();
+                debug!("Peers to send HB {:?}", peers);
+
+                match node.send_heartbeat_message(peers.into_iter()).await {
+                    Ok(unsent_peers) => {
+                        if !unsent_peers.is_empty() {
+                            warn!("Following peers failed to receive HB probe: {unsent_peers:?}");
+                            node.flush_stale_peers(unsent_peers).await;
+                        }
+                    }
+                    Err(e) => error!("Error sending Heartbeat {e:?}"),
+                }
+            }
+        })
     }
 
     fn is_compatible(&self, node_type: NodeType, network_version: u32) -> bool {
@@ -284,7 +332,7 @@ impl Node {
     async fn listen(self, listener: TcpTlsListner) -> Result<Self> {
         let node = self.clone();
         let (close_tx, close_rx) = oneshot::channel();
-        let handle = tokio::spawn(
+        let handle = spawn(
             async move {
                 trace!("listen");
 
@@ -545,7 +593,7 @@ impl Node {
                 let msg = msg.clone();
                 let unsent_list = unsent_nodes.clone();
 
-                tokio::spawn(async move {
+                spawn(async move {
                     if let Err(error) = node.send_message(peer, msg).await {
                         warn!(?error, "send_multicast");
                         if let CommsError::PeerNotFound(_) = error {
@@ -659,6 +707,26 @@ impl Node {
             .send_multicast(peers, CommMessage::Direct { payload, id })
             .await;
         Ok(unsent_nodes)
+    }
+
+    // Sends a HeartBeat message to given peers.
+    async fn send_heartbeat_message(
+        &mut self,
+        peers: impl Iterator<Item = SocketAddr>,
+    ) -> Result<Vec<SocketAddr>> {
+        let id = rand::thread_rng().gen();
+        let unsent_nodes = self
+            .send_multicast(peers, CommMessage::HeartBeatProbe(id))
+            .await;
+        Ok(unsent_nodes)
+    }
+
+    async fn flush_stale_peers(&self, stale_peers: Vec<SocketAddr>) {
+        debug!("Flushing stale peers {stale_peers:?}");
+        self.peers
+            .write()
+            .await
+            .retain(|addr, _| !stale_peers.contains(addr))
     }
 
     /// Prepares and sends a handshake message to a given peer.
@@ -804,6 +872,9 @@ impl Node {
                         warn!(?error, "handle_gossip");
                     }
                 }
+                CommMessage::HeartBeatProbe(id) => {
+                    debug!("HeartBeat message from {peer_addr:?} with ID: {id:?}");
+                }
                 other => {
                     warn!(?other, "Received unexpected message; ignoring");
                 }
@@ -856,7 +927,7 @@ impl Node {
         let node = self.clone();
         let payload = payload.clone();
 
-        tokio::spawn(async move {
+        spawn(async move {
             let _ = node
                 .send_multicast(
                     peers.into_iter(),
@@ -1001,7 +1072,7 @@ impl Node {
             // Connect to all previously unknown peers (in the background - i.e. we don't wait for these connections to succeed).
             for &peer in unknown_peers {
                 let mut node = self.clone();
-                tokio::spawn(
+                spawn(
                     async move {
                         if let Err(error) = node.connect_to(peer).await {
                             warn!(?error, "connect_to failed");
@@ -1050,7 +1121,7 @@ impl Node {
 
         // Spawn the sender task.
         // Redirect messages from the mpsc channel into the TCP socket
-        let sock_out_h = tokio::spawn(
+        let sock_out_h = spawn(
             async move {
                 let send_rx = async_stream::stream! {
                     while let Some(item) = send_rx.recv().await {
@@ -1070,7 +1141,7 @@ impl Node {
         // Spawn the receiver task which will redirect the incoming messages into the MPSC channel
         // and manage the peer state transitions.
         let (messages, close_receiver_tx) = get_messages_stream(sock_in);
-        let sock_in_h = tokio::spawn({
+        let sock_in_h = spawn({
             let mut node = self.clone();
             let send_tx = send_tx.clone().into();
             let peers = self.peers.clone();
@@ -1299,6 +1370,7 @@ mod test {
             peer_limit,
             NodeType::Compute,
             network_version,
+            false,
             false,
         )
         .await

--- a/src/comms_handler/tests.rs
+++ b/src/comms_handler/tests.rs
@@ -586,7 +586,7 @@ async fn create_config_compute_nodes(configs: Vec<TcpTlsConfig>, peer_limit: usi
     let mut nodes = Vec::new();
     for tcp_tls_config in configs {
         nodes.push(
-            Node::new(&tcp_tls_config, peer_limit, NodeType::Compute, false)
+            Node::new(&tcp_tls_config, peer_limit, NodeType::Compute, false, false)
                 .await
                 .unwrap(),
         );
@@ -609,6 +609,7 @@ async fn create_node_type_version(
         peer_limit,
         node_type,
         network_version,
+        false,
         false,
     )
     .await

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -191,7 +191,14 @@ impl ComputeNode {
             .compute_api_use_tls
             .then(|| tcp_tls_config.clone_private_info());
 
-        let node = Node::new(&tcp_tls_config, config.peer_limit, NodeType::Compute, false).await?;
+        let node = Node::new(
+            &tcp_tls_config,
+            config.peer_limit,
+            NodeType::Compute,
+            false,
+            true,
+        )
+        .await?;
         let node_raft = ComputeRaft::new(&config, extra.raft_db.take()).await;
 
         if config.backup_restore.unwrap_or(false) {

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -326,6 +326,7 @@ pub enum CommMessage {
         /// Unique message ID. Can be used for correspondence between requests and responses.
         id: Token,
     },
+    HeartBeatProbe(Token),
 }
 
 ///============ STORAGE NODE ============///

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -205,6 +205,7 @@ impl MinerNode {
             config.peer_limit,
             NodeType::Miner,
             disable_tcp_listener,
+            false,
         )
         .await?;
         let api_pow_info = to_route_pow_infos(config.routes_pow.clone());

--- a/src/pre_launch.rs
+++ b/src/pre_launch.rs
@@ -144,6 +144,7 @@ impl PreLaunchNode {
             config.peer_limit,
             NodeType::PreLaunch,
             false,
+            false,
         )
         .await?;
         let db = {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -170,7 +170,14 @@ impl StorageNode {
             .then(|| tcp_tls_config.clone_private_info());
         let api_keys = to_api_keys(config.api_keys.clone());
 
-        let node = Node::new(&tcp_tls_config, config.peer_limit, NodeType::Storage, false).await?;
+        let node = Node::new(
+            &tcp_tls_config,
+            config.peer_limit,
+            NodeType::Storage,
+            false,
+            false,
+        )
+        .await?;
         let node_raft = StorageRaft::new(&config, extra.raft_db.take());
         let catchup_fetch = StorageFetch::new(&config, addr);
         let api_pow_info = to_route_pow_infos(config.routes_pow.clone());

--- a/src/user.rs
+++ b/src/user.rs
@@ -166,6 +166,7 @@ impl UserNode {
             config.peer_limit,
             NodeType::User,
             disable_tcp_listener,
+            false,
         )
         .await?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -836,6 +836,7 @@ pub fn decode_signature(sig: &str) -> Result<Signature, StringError> {
 ///
 /// * `node_conn` - Node to use for connections
 pub async fn shutdown_connections(node_conn: &mut Node) {
+    node_conn.abort_heartbeat_handle();
     join_all(node_conn.stop_listening().await).await;
     join_all(node_conn.disconnect_all(None).await).await;
 }


### PR DESCRIPTION
- Compute nodes send a heartbeat message to all their known peers to identify and flush stale peers that cannot receive the message.