### PR TITLE
Force TLS configuration supply for API access on Compute and Storage

### DIFF
--- a/src/bin/node/compute.rs
+++ b/src/bin/node/compute.rs
@@ -76,7 +76,7 @@ pub async fn run_node(matches: &ArgMatches<'_>) {
                     .run(bind_address)
                     .await;
             } else {
-                serve.run(bind_address).await;
+                panic!("TLS not configured. Please provide a valid TLS configuration for API access and restart.");
             }
         }
     });

--- a/src/bin/node/storage.rs
+++ b/src/bin/node/storage.rs
@@ -72,7 +72,7 @@ pub async fn run_node(matches: &ArgMatches<'_>) {
                     .run(bind_address)
                     .await;
             } else {
-                serve.run(bind_address).await;
+                panic!("TLS not configured. Please provide a valid TLS configuration for API access and restart.");
             }
         }
     });


### PR DESCRIPTION
## Description
This PR forces Compute and Storage nodes to be started with a TLS configuration, and will panic exit them if the config isn't present.

Fixes #2001304 on HackerOne platform. Issue is currently private, so I won't post a link here. **This PR should not be merged in until the necessary changes have been made in the production environment to support this (principally, disabling the existing Nginx reverse proxy)**

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [ ] I have added/updated relevant tests to ensure the changes are properly covered.
- [ ] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.